### PR TITLE
fix: correct the artifact path in CI config file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         with:
           name: mono-repos-dist
           path: |
-            packages/**/dist/**
+            packages/*/lib/**
 
   publish:
     needs: [build, test]
@@ -73,6 +73,7 @@ jobs:
         uses: actions/download-artifact@v3
         with:
           name: mono-repos-dist
+          path: packages
 
       - name: Publish (development)
         if: github.event.pull_request.head.repo.full_name == 'RightCapitalHQ/frontend-libraries' && github.base_ref == github.event.repository.default_branch

--- a/packages/exceptions/package.json
+++ b/packages/exceptions/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@rightcapital/exceptions",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "TypeScript Exception definitions inspired by PHP SPL Exceptions etc...",
   "author": "RightCapital Ecosystem team <npm-publisher@rightcapital.com>",
   "keywords": [


### PR DESCRIPTION
Fix the issue that CI publishes an empty package, it caused by the wrong artifact path setting in the CI 

## Pull Request type
Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

CI publishes an empty package

## What is the new behavior?

CI could publish the correct package with the lib directory

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
