### PR TITLE
fix(date-helpers): correct package entry points and include TypeDoc in _.d.ts_ for npm release

### DIFF
--- a/change/@rightcapital-date-helpers-ebcbc19d-09cb-426b-88d2-3b8003247078.json
+++ b/change/@rightcapital-date-helpers-ebcbc19d-09cb-426b-88d2-3b8003247078.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(date-helpers): correct package entry points and include TypeDoc in _.d.ts_ for npm release",
+  "packageName": "@rightcapital/date-helpers",
+  "email": "38807139+liby@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/date-helpers/package.json
+++ b/packages/date-helpers/package.json
@@ -16,8 +16,8 @@
   "homepage": "https://www.rightcapital.com",
   "license": "MIT",
   "packageManager": "pnpm@8.9.2",
-  "main": "lib/index.js",
-  "typings": "lib/index.d.ts",
+  "main": "lib/date-helpers.js",
+  "typings": "lib/date-helpers.d.ts",
   "directories": {
     "lib": "lib",
     "test": "__tests__"

--- a/packages/date-helpers/tsconfig.json
+++ b/packages/date-helpers/tsconfig.json
@@ -2,7 +2,9 @@
   "extends": "../../tsconfig.json",
   "compilerOptions": {
     "rootDir": "./src",
-    "outDir": "./lib"
+    "outDir": "./lib",
+    "declaration": true,
+    "removeComments": false
   },
   "references": [
     {


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
1. There were issues related to the incorrect `main` and `typings` paths in _package.json_, affecting the package's proper functionality when installed via npm.
2. The generated _.d.ts_ files lacked TypeDoc annotations, hindering inline documentation for developers.
    <img width="1344" alt="image" src="https://github.com/RightCapitalHQ/frontend-libraries/assets/38807139/f3d414f4-93d3-45b4-81d2-e6687cf216af">


Issue Number: N/A

## What is the new behavior?

- Corrected `main` and `typings` paths ensure proper package import after npm installation.
- TypeDoc annotations are now included in _.d.ts_ files, providing enriched inline documentation.
    <img width="1428" alt="image" src="https://github.com/RightCapitalHQ/frontend-libraries/assets/38807139/17442b19-441b-4e23-b09f-765956f5630a">

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
