### PR TITLE
chore(exceptions): improve the type declaration to qualify strict type check

### DIFF
--- a/packages/exceptions/src/exceptions/base.exception.ts
+++ b/packages/exceptions/src/exceptions/base.exception.ts
@@ -13,7 +13,7 @@ export class BaseException extends Error {
    */
   public constructor(
     message: string,
-    public cause?: any,
+    public cause?: unknown,
   ) {
     super(message);
   }
@@ -24,7 +24,7 @@ export class BaseException extends Error {
    * @param cause the cause we assume that cause the current exception
    * @returns true if the cause we passed is the original cause when the Exception constructed. otherwise, it returns false
    */
-  public isCausedBy(cause) {
+  public isCausedBy(cause: unknown) {
     return cause === this.cause;
   }
 }


### PR DESCRIPTION
# Type declaration improvement for exceptions

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [x] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

BaseException's property cause is with `any` type. 

## What is the new behavior?

follow the idea from https://github.com/RightCapitalHQ/frontend-libraries/pull/25#discussion_r1361885045

update the cause property's type to `unknown`.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No