### PR TITLE
docs: update README files to add API Reference link for new packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ This is a Mono repository contains a set of useful libraries/helpers in TypeScri
 
 it including the following packages:
 
-- @rightcapital/exceptions: This library provides a set of standard Exceptions ([docs](https://github.com/RightCapitalHQ/frontend-libraries/tree/main/packages/exceptions/docs))
+- @rightcapital/exceptions: This library provides a set of standard Exceptions ([API Reference](https://github.com/RightCapitalHQ/frontend-libraries/tree/main/packages/exceptions/docs))
+- @rightcapital/date-helpers: A utility class providing various date formatting and parsing methods in TypeScript. ([API Reference](https://github.com/RightCapitalHQ/frontend-libraries/blob/main/packages/date-helpers/docs/modules.md))
 
 ## Development
 

--- a/change/@rightcapital-exceptions-750cd51a-cc98-405e-af90-0a155313368b.json
+++ b/change/@rightcapital-exceptions-750cd51a-cc98-405e-af90-0a155313368b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "docs: update README files to add API Reference link for new packages",
+  "packageName": "@rightcapital/exceptions",
+  "email": "i@rainx.cc",
+  "dependentChangeType": "patch"
+}

--- a/packages/exceptions/README.md
+++ b/packages/exceptions/README.md
@@ -37,6 +37,6 @@ try {
 }
 ```
 
-## Modules
+## API Reference
 
 [Here](/packages/exceptions/docs/modules.md) is the API documentation for the modules included in the package.


### PR DESCRIPTION
1. Add `API Reference` link to README file for date-helpers package.
2. update the title of the `API Reference` of the exceptions package to API Reference (before it is called `Modules` )

## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):


## Does this introduce a breaking change?

- [ ] Yes
- [ ] No

