### PR TITLE
chore(build): upgrade artifacts related actions to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ jobs:
         run: pnpm run test
 
       - name: Archive build artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: build-artifacts
           path: |
@@ -43,7 +43,7 @@ jobs:
       - run: pnpm install
 
       - name: Download build artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: build-artifacts
           path: packages/


### PR DESCRIPTION
Upgrade artifacts related actions to v4

It would fail when upgrading them(upload-artifact, download-artifact) individually. 
 
<img width="1290" alt="image" src="https://github.com/RightCapitalHQ/frontend-libraries/assets/101971/c029d0d5-dca0-4f4d-b751-62340ef5d505">


## Pull Request type

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [x] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the new behavior?

nothing changes

## Does this introduce a breaking change?

- [ ] Yes
- [x] No
