### PR TITLE
ci: workaround Renvoate `postUpgradeTasks` restriction for generating changefiles

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
     branches: [main]
 
 jobs:
-  build_and_test:
+  build-and-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -30,8 +30,43 @@ jobs:
           path: |
             packages/*/lib/**
 
+  check-renovate-changefile:
+    if: startsWith(github.event.pull_request.head.ref, 'renovate/') && github.base_ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          token: ${{ secrets.RENOVATE_AUTO_BEACHBALL_CHANGEFILE_TOKEN }}
+
+      # Install dependencies (example using pnpm)
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - run: pnpm install
+
+      - name: Check and generate changefile for Renovate
+        uses: RightCapitalHQ/frontend-style-guide/.github/actions/renovate-auto-beachball-changefile@main
+
+  check-beachball-changefile:
+    if: github.base_ref == github.event.repository.default_branch
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4.0.2
+        with:
+          node-version-file: .node-version
+          cache: pnpm
+      - run: pnpm install
+
+      - name: Check
+        run: pnpm exec beachball check
+
   publish:
-    needs: build_and_test
+    needs: [build-and-test, check-beachball-changefile]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/renovate.json
+++ b/renovate.json
@@ -7,27 +7,11 @@
   "automergeType": "pr",
   "platformAutomerge": true,
   "prCreation": "immediate",
-  "postUpgradeTasks": {
-    "commands": [
-      "git add --all",
-      "npx beachball change --no-fetch --no-commit --type patch --message '{{{commitMessage}}}'",
-      "git reset"
-    ],
-    "executionMode": "branch",
-    "fileFilters": ["change/*.json"]
-  },
+  "commitBody": "Beachball-bump-type: patch",
   "lockFileMaintenance": {
     "automerge": true,
     "enabled": true,
-    "postUpgradeTasks": {
-      "commands": [
-        "git add --all",
-        "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
-        "git reset"
-      ],
-      "executionMode": "branch",
-      "fileFilters": ["change/*.json"]
-    }
+    "commitBody": "Beachball-bump-type: none"
   },
   "packageRules": [
     {
@@ -44,15 +28,7 @@
       "groupName": "DevDependencies",
       "groupSlug": "auto-merge-dev-dependencies-updates",
       "matchDepTypes": ["devDependencies"],
-      "postUpgradeTasks": {
-        "commands": [
-          "git add --all",
-          "npx beachball change --no-fetch --no-commit --type none --message '{{{commitMessage}}}'",
-          "git reset"
-        ],
-        "fileFilters": ["change/*.json"],
-        "executionMode": "branch"
-      }
+      "commitBody": "Beachball-bump-type: none"
     }
   ]
 }


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple pull requests if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): Renovate

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Renovate failed to update dependencies: https://github.com/RightCapitalHQ/phpdoc-parser/pull/220#issuecomment-2327854227

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

Renovate will properly update dependencies without issue.

## Does this introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

A secret named `RENOVATE_AUTO_BEACHBALL_CHANGEFILE_TOKEN` with a token that have write access to this repository is required for this PR to work.

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->
