### PR TITLE
feat(assertion-helpers): add Agent Skill for AI coding agent integration

### DIFF
--- a/change/@rightcapital-assertion-helpers-f456f13b-c34f-4372-b6a3-e966920158ba.json
+++ b/change/@rightcapital-assertion-helpers-f456f13b-c34f-4372-b6a3-e966920158ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add Agent Skill for AI coding agent integration",
+  "packageName": "@rightcapital/assertion-helpers",
+  "email": "45930107+PinkChampagne17@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -10,6 +10,8 @@ module.exports = {
       'always',
       [
         // MEMO: pnpm -r ls --depth -1
+        'assertion-helpers',
+        'color-helpers',
         'date-helpers',
         'exceptions',
       ],

--- a/packages/assertion-helpers/README.md
+++ b/packages/assertion-helpers/README.md
@@ -33,6 +33,31 @@ const admin = AssertionHelpers.ensure(
 // admin is now typed as AdminUser
 ```
 
+## Agent Skills
+
+This package ships with an [Agent Skill](https://agentskills.io) that teaches AI
+coding agents (Claude Code, Cursor, etc.) how to use the assertion-helpers API
+correctly, following the
+[npm-based Agent Skills Convention](https://github.com/antfu/skills-npm).
+
+### Automatic discovery (recommended)
+
+If your project uses [`skills-npm`](https://github.com/antfu/skills-npm), the
+skill is discovered automatically from `node_modules`:
+
+```bash
+npx skills-npm
+```
+
+### Manual installation
+
+You can also install the skill directly using the
+[`skills` CLI](https://github.com/vercel-labs/skills):
+
+```bash
+npx skills add https://github.com/RightCapitalHQ/frontend-libraries/tree/main/packages/assertion-helpers/skills
+```
+
 ## API Reference
 
 See the [generated documentation](./docs/README.md) for detailed API reference.

--- a/packages/assertion-helpers/package.json
+++ b/packages/assertion-helpers/package.json
@@ -25,7 +25,8 @@
     "lib": "lib"
   },
   "files": [
-    "lib"
+    "lib",
+    "skills"
   ],
   "scripts": {
     "build": "tsc --build tsconfig.build.json",

--- a/packages/assertion-helpers/skills/assertion-helpers/SKILL.md
+++ b/packages/assertion-helpers/skills/assertion-helpers/SKILL.md
@@ -1,0 +1,150 @@
+---
+name: assertion-helpers
+description: >-
+  Type-safe assertion and validation utilities for defensive TypeScript programming.
+  Use when you need runtime assertions, null checks with type narrowing, type guard
+  validation, unreachable code markers, or exhaustive switch/if-else checking.
+  Import AssertionHelpers from @rightcapital/assertion-helpers.
+license: MIT
+metadata:
+  author: RightCapital
+  package: '@rightcapital/assertion-helpers'
+---
+
+# assertion-helpers
+
+Type-safe assertion utilities for defensive programming in TypeScript. All methods are static on the `AssertionHelpers` class and throw `UnexpectedValueException` (from `@rightcapital/exceptions`) on failure.
+
+## Import
+
+```typescript
+import { AssertionHelpers } from '@rightcapital/assertion-helpers';
+```
+
+## Quick Reference
+
+| Method                                     | Purpose                             | Returns                            | Use When                                     |
+| ------------------------------------------ | ----------------------------------- | ---------------------------------- | -------------------------------------------- |
+| `assert(value, message?)`                  | Verify condition is strictly `true` | void (narrows type)                | Validating preconditions/postconditions      |
+| `assertNonNullable(value, message?)`       | Verify not null/undefined           | void (narrows to `NonNullable<T>`) | Guarding against null in statements          |
+| `ensure(value, predicate, message?)`       | Validate with type guard            | narrowed value `S`                 | Need validated value in an expression        |
+| `ensureNonNullable(value, message?)`       | Verify not null/undefined           | `NonNullable<T>`                   | Need non-null value in an expression         |
+| `assertUnreachable(message?)`              | Mark unreachable code               | never                              | Defensive code paths that should not execute |
+| `assertExhaustive(value: never, message?)` | Exhaustiveness check                | never                              | `default` case in switch over union types    |
+
+## Key Distinction: assert vs ensure
+
+- **`assert*` methods** are _statements_: they narrow the type of their argument for subsequent code but do not return a value. Use them to guard a code block.
+- **`ensure*` methods** are _expressions_: they return the validated value with a narrowed type. Use them inline in assignments, arguments, or chaining.
+
+```typescript
+// Statement form — narrows `user` for subsequent code
+AssertionHelpers.assertNonNullable(user);
+console.log(user.name); // user is NonNullable<T>
+
+// Expression form — returns the validated value
+const userName = AssertionHelpers.ensureNonNullable(user).name;
+```
+
+## Critical: `assert()` Uses Strict Boolean Checking
+
+`assert(value)` checks `value !== true`. This means falsy values like `0`, `""`, `NaN`, and `false` **all** trigger the exception — but so do truthy non-boolean values like objects and non-empty strings.
+
+```typescript
+// WRONG — throws even though user is a valid object
+AssertionHelpers.assert(user);
+
+// CORRECT — use assertNonNullable for null/undefined checks
+AssertionHelpers.assertNonNullable(user);
+
+// CORRECT — pass a boolean expression to assert
+AssertionHelpers.assert(user.age >= 18, 'Must be 18+');
+```
+
+## Usage Patterns
+
+### Precondition validation
+
+```typescript
+function processOrder(order: Order) {
+  AssertionHelpers.assert(order.items.length > 0, 'Order must have items');
+  AssertionHelpers.assert(order.total > 0, 'Order total must be positive');
+  // proceed with valid order...
+}
+```
+
+### Null-safe access after assertion
+
+```typescript
+function initApp(config: AppConfig | null) {
+  AssertionHelpers.assertNonNullable(config, 'Config is required');
+  // config is now typed as AppConfig
+  startServer(config.port);
+}
+```
+
+### Inline validated assignment with type guard
+
+```typescript
+function isAdminUser(user: User): user is AdminUser {
+  return user.role === 'admin';
+}
+
+const admin = AssertionHelpers.ensure(
+  currentUser,
+  isAdminUser,
+  'Admin required',
+);
+// admin is typed as AdminUser
+```
+
+### Inline non-null access
+
+```typescript
+const element = AssertionHelpers.ensureNonNullable(
+  document.getElementById('app'),
+  'App container not found',
+);
+element.classList.add('loaded');
+```
+
+### Exhaustive switch statements
+
+```typescript
+type Shape =
+  | { kind: 'circle'; radius: number }
+  | { kind: 'square'; side: number };
+
+function area(shape: Shape): number {
+  switch (shape.kind) {
+    case 'circle':
+      return Math.PI * shape.radius ** 2;
+    case 'square':
+      return shape.side ** 2;
+    default:
+      // TypeScript error if a new Shape kind is added but not handled
+      return AssertionHelpers.assertExhaustive(shape);
+  }
+}
+```
+
+### Defensive unreachable branches
+
+```typescript
+function processStatus(status: 'active' | 'inactive' | 'activating') {
+  if (status === 'active') {
+    activate();
+  } else if (status === 'inactive') {
+    deactivate();
+  } else {
+    // Business logic says this should never happen here
+    AssertionHelpers.assertUnreachable(`Unexpected status: ${status}`);
+  }
+}
+```
+
+## Common Mistakes
+
+- **Do not use `assert()` for null checks.** It checks `value !== true`, not truthiness. Use `assertNonNullable()` instead.
+- **Do not confuse `assertUnreachable` with `assertExhaustive`.** Use `assertExhaustive` in `default` cases of switch statements over union types — it accepts `never` and catches missing branches at compile time. Use `assertUnreachable` for logically impossible branches that TypeScript cannot prove unreachable.
+- **Choose the right form.** Use `assert*` when you only need type narrowing for subsequent code. Use `ensure*` when you need the validated value as an expression (assignment, argument, chaining).


### PR DESCRIPTION
## Summary

- Add `SKILL.md` following the [npm-based Agent Skills Convention](https://github.com/antfu/skills-npm), enabling AI coding agents (Claude Code, Cursor, etc.) to automatically discover and learn how to use the `@rightcapital/assertion-helpers` API when the package is installed
- Add `"skills"` to `package.json` `files` array so the skill is included in npm publishes
- Add "Agent Skills" section to `README.md` with [`skills-npm`](https://github.com/antfu/skills-npm) (automatic) and [`skills` CLI](https://github.com/vercel-labs/skills) (manual) installation instructions
- Fix pre-existing gap in `commitlint.config.js`: add missing `assertion-helpers` and `color-helpers` scopes to `scope-enum`
- Minor version bump via beachball change file

## Test plan

- [ ] `cd packages/assertion-helpers && pnpm pack --dry-run` — verify `skills/assertion-helpers/SKILL.md` is included in the tarball
- [ ] `pnpm -w build` — build passes
- [ ] `pnpm -w check` — beachball change file is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)