### PR TITLE
chore(renovate): update assignee/reviewer from rainx to frantic1048

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,8 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>RightCapitalHQ/renovate-config:library"],
-  "assignees": ["rainx"],
-  "reviewers": ["rainx"],
+  "assignees": ["frantic1048"],
+  "reviewers": ["frantic1048"],
   "labels": ["dependencies"],
   "automergeType": "pr",
   "platformAutomerge": true,


### PR DESCRIPTION
Updates the Renovate config to replace the departed/renamed assignee & reviewer `rainx` with `frantic1048`.

- `assignees`: `rainx` → `frantic1048`
- `reviewers`: `rainx` → `frantic1048`

Historical CHANGELOG entries were intentionally left untouched.