### PR TITLE
feat: rename storage-factory to storage-factory-next

### DIFF
--- a/.nx/version-plans/rename-storage-factory-next.md
+++ b/.nx/version-plans/rename-storage-factory-next.md
@@ -1,0 +1,5 @@
+---
+storage-factory-next: major
+---
+
+Rename storage-factory to @rightcapital/storage-factory-next

--- a/forks/storage-factory/README.md
+++ b/forks/storage-factory/README.md
@@ -1,4 +1,4 @@
-# @rightcapital-fork/storage-factory
+# @rightcapital/storage-factory-next
 
 > Forked from [MichalZalecki/storage-factory](https://github.com/MichalZalecki/storage-factory)
 
@@ -21,13 +21,13 @@ This fork includes the following modifications:
 ## Installation
 
 ```bash
-npm install @rightcapital-fork/storage-factory
+npm install @rightcapital/storage-factory-next
 ```
 
 ## Usage
 
 ```ts
-import { storageFactory } from '@rightcapital-fork/storage-factory';
+import { storageFactory } from '@rightcapital/storage-factory-next';
 
 export const local = storageFactory(() => localStorage);
 export const session = storageFactory(() => sessionStorage);
@@ -48,11 +48,11 @@ function login(token: string) {
 
 ```bash
 # Build
-pnpm exec nx build storage-factory
+pnpm exec nx build storage-factory-next
 
 # Type check
-pnpm exec nx typecheck storage-factory
+pnpm exec nx typecheck storage-factory-next
 
 # Run tests
-pnpm exec vitest --project storage-factory
+pnpm exec vitest --project storage-factory-next
 ```

--- a/forks/storage-factory/package.json
+++ b/forks/storage-factory/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "@rightcapital-fork/storage-factory",
-  "version": "1.0.0",
+  "name": "@rightcapital/storage-factory-next",
+  "version": "0.0.0",
   "description": "Because using localStorage directly is a bad idea",
   "author": "RightCapital Ecosystem team <npm-publisher@rightcapital.com>",
   "repository": {
@@ -16,7 +16,8 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "import": "./lib/index.js"
+      "import": "./lib/index.js",
+      "default": "./lib/index.js"
     },
     "./package.json": "./package.json"
   },

--- a/forks/storage-factory/project.json
+++ b/forks/storage-factory/project.json
@@ -1,6 +1,6 @@
 {
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
-  "name": "storage-factory",
+  "name": "storage-factory-next",
   "projectType": "library",
   "sourceRoot": "forks/storage-factory/src",
   "targets": {}

--- a/forks/storage-factory/tsconfig.json
+++ b/forks/storage-factory/tsconfig.json
@@ -3,7 +3,7 @@
   "compilerOptions": {
     "composite": true,
     "rootDir": ".",
-    "outDir": "./node_modules/.cache/rightcapital/typecheck/storage-factory",
+    "outDir": "./node_modules/.cache/rightcapital/typecheck/storage-factory-next",
     "module": "ESNext",
     "moduleResolution": "bundler",
     "lib": ["ES2018", "DOM"],

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -45,7 +45,7 @@ export default defineConfig({
       }),
       defineProject({
         test: {
-          name: 'storage-factory',
+          name: 'storage-factory-next',
           environment: 'happy-dom',
           include: [
             'forks/storage-factory/**/__tests__/**/*.ts?(x)',


### PR DESCRIPTION
<!--- Please provide a general summary of your changes in the title above -->

## Pull Request type

<!-- Please try to limit your pull request to one type; submit multiple PRs if needed. -->

Please check the type of change your PR introduces:

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [x] Other (please describe): Rename package name

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

This package is currently published and referenced as `@rightcapital-fork/storage-factory`, and the Nx project / docs / commands still use `storage-factory`.

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added by this PR. -->

- Rename the npm package to `@rightcapital/storage-factory-next`.
- Rename the Nx project and local references to `storage-factory-next`.
- Update README usage and development commands to match the new package/project name.
- Keep the runtime API and implementation behavior unchanged.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this does introduce a breaking change, please describe the impact and migration path for existing applications below. -->

Yes. Existing consumers must update their dependency and imports from `@rightcapital-fork/storage-factory` to `@rightcapital/storage-factory-next`, and update any Nx command references from `storage-factory` to `storage-factory-next`.

## Other information

<!-- Any other information that is important to this PR, such as screenshots of how the component looks before and after the change. -->

This is a rename-only release. The version plan marks the package as a major change.