### PR TITLE
fix: correct storage factory release history

### DIFF
--- a/.nx/version-plans/rename-storage-factory-next.md
+++ b/.nx/version-plans/rename-storage-factory-next.md
@@ -1,5 +1,0 @@
----
-storage-factory-next: major
----
-
-Rename storage-factory to @rightcapital/storage-factory-next

--- a/forks/storage-factory/CHANGELOG.md
+++ b/forks/storage-factory/CHANGELOG.md
@@ -1,10 +1,9 @@
-## 1.0.0 (2026-06-04)
+## 1.0.0 (2026-07-10)
 
 ### ⚠️  Breaking Changes
 
-- ESM-only (removed CommonJS build) ([30a60cf](https://github.com/RightCapitalHQ/frontend-libraries/commit/30a60cf))
+- Rename storage-factory to @rightcapital/storage-factory-next ([6e1f2b2](https://github.com/RightCapitalHQ/frontend-libraries/commit/6e1f2b2))
 
 ### ❤️ Thank You
 
-- Codex
 - Pink Champagne @PinkChampagne17

--- a/nx.json
+++ b/nx.json
@@ -47,6 +47,7 @@
         "prettier.config.*",
         "eslint.config.*",
         "vitest.config.*",
+        "**/CHANGELOG.md",
         ".pnpm-store/**",
         ".vscode/**",
         "pnpm-lock.yaml"


### PR DESCRIPTION
## Summary

- correct the `@rightcapital/storage-factory-next@1.0.0` changelog date and release entry
- remove the stale major version plan that was already applied to the published `1.0.0`
- ignore changelog-only edits during version-plan checks so release-history corrections do not require another package bump
- update the published `1.0.0` GitHub release notes to match the corrected changelog

## Background

The original `0.0.0 -> 1.0.0` release applied the package rename plan, but Nx produced no changelog file diff because the reused project directory already contained a dated `1.0.0` entry from the previous package identity. Nx then returned before deleting the applied plan. The stale plan subsequently caused release PR #278 to propose an unnecessary `2.0.0` bump.

The release action guard for this failure mode is tracked in RightCapitalHQ/actions#33.

After this cleanup merges, the release PR workflow should regenerate #278 without the `storage-factory-next` bump.

## Validation

- `pnpm run check`
- `pnpm run build`
- `pnpm run lint`
- `pnpm run test` (63 tests passed)