### PR TITLE
feat!: rename `AssertError` to `AssertionError`

### DIFF
--- a/.nx/version-plans/rename-assertion-error.md
+++ b/.nx/version-plans/rename-assertion-error.md
@@ -1,0 +1,7 @@
+---
+assert: major
+---
+
+Rename the exported `AssertError` class to `AssertionError`.
+
+This is a breaking API change. Update imports and `instanceof` checks from `AssertError` to `AssertionError`.

--- a/packages/assert/README.md
+++ b/packages/assert/README.md
@@ -95,17 +95,17 @@ assertNonNullable(user, 'User cannot be null');
 // `user` is narrowed to NonNullable<User>
 ```
 
-### Error Handling (`AssertError`)
+### Error Handling (`AssertionError`)
 
-All assertion functions throw `AssertError` (which extends `Error`) when an assertion fails.
+All assertion functions throw `AssertionError` (which extends `Error`) when an assertion fails.
 
 ```typescript
-import { assert, AssertError } from '@rightcapital/assert';
+import { assert, AssertionError } from '@rightcapital/assert';
 
 try {
   assert(user.age >= 18, 'User must be at least 18 years old');
 } catch (error) {
-  if (error instanceof AssertError) {
+  if (error instanceof AssertionError) {
     console.error('Assertion failed:', error.message);
   }
 }
@@ -115,7 +115,7 @@ try {
 
 | API                              | Return / Type Behavior            | Typical Use Case                                      |
 | :------------------------------- | :-------------------------------- | :---------------------------------------------------- |
-| `AssertError`                    | `class extends Error`             | Error thrown on assertion failure                     |
+| `AssertionError`                 | `class extends Error`             | Error thrown on assertion failure                     |
 | `assertExhaustive(value, msg?)`  | `never`                           | Enforce exhaustiveness check in `switch` or `if-else` |
 | `assertUnreachable(msg?)`        | `never`                           | Mark logically unreachable code branches              |
 | `ensure(value, predicate, msg?)` | `S extends T`                     | Validate and return value with narrowed type          |

--- a/packages/assert/__tests__/assert.test.ts
+++ b/packages/assert/__tests__/assert.test.ts
@@ -2,22 +2,22 @@ import { describe, expect, it } from 'vitest';
 
 import {
   assert,
-  AssertError,
   assertExhaustive,
+  AssertionError,
   assertNonNullable,
   assertUnreachable,
   ensure,
   ensureNonNullable,
 } from '../src';
 
-describe(AssertError.name, () => {
+describe(AssertionError.name, () => {
   it('should extend Error with its own name', () => {
-    const error = new AssertError('Assertion failed');
+    const error = new AssertionError('Assertion failed');
 
     expect(error).toBeInstanceOf(Error);
-    expect(error).toBeInstanceOf(AssertError);
-    expect(error.name).toBe('AssertError');
-    expect(String(error)).toBe('AssertError: Assertion failed');
+    expect(error).toBeInstanceOf(AssertionError);
+    expect(error.name).toBe('AssertionError');
+    expect(String(error)).toBe('AssertionError: Assertion failed');
   });
 });
 
@@ -27,14 +27,14 @@ describe(assert.name, () => {
   });
 
   it('should throw when value is falsy', () => {
-    expect(() => assert(null)).toThrow(AssertError);
-    expect(() => assert(undefined)).toThrow(AssertError);
-    expect(() => assert(false)).toThrow(AssertError);
-    expect(() => assert(NaN)).toThrow(AssertError);
-    expect(() => assert(0)).toThrow(AssertError);
-    expect(() => assert(-0)).toThrow(AssertError);
-    expect(() => assert(0n)).toThrow(AssertError);
-    expect(() => assert('')).toThrow(AssertError);
+    expect(() => assert(null)).toThrow(AssertionError);
+    expect(() => assert(undefined)).toThrow(AssertionError);
+    expect(() => assert(false)).toThrow(AssertionError);
+    expect(() => assert(NaN)).toThrow(AssertionError);
+    expect(() => assert(0)).toThrow(AssertionError);
+    expect(() => assert(-0)).toThrow(AssertionError);
+    expect(() => assert(0n)).toThrow(AssertionError);
+    expect(() => assert('')).toThrow(AssertionError);
   });
 
   it('should throw with custom message', () => {
@@ -54,11 +54,11 @@ describe(assertNonNullable.name, () => {
   });
 
   it('should throw for null', () => {
-    expect(() => assertNonNullable(null)).toThrow(AssertError);
+    expect(() => assertNonNullable(null)).toThrow(AssertionError);
   });
 
   it('should throw for undefined', () => {
-    expect(() => assertNonNullable(undefined)).toThrow(AssertError);
+    expect(() => assertNonNullable(undefined)).toThrow(AssertionError);
   });
 
   it('should throw with custom message', () => {
@@ -77,7 +77,7 @@ describe(ensure.name, () => {
   });
 
   it('should throw when predicate fails', () => {
-    expect(() => ensure(123, isString)).toThrow(AssertError);
+    expect(() => ensure(123, isString)).toThrow(AssertionError);
   });
 
   it('should throw with custom message', () => {
@@ -101,11 +101,11 @@ describe(ensureNonNullable.name, () => {
   });
 
   it('should throw for null', () => {
-    expect(() => ensureNonNullable(null)).toThrow(AssertError);
+    expect(() => ensureNonNullable(null)).toThrow(AssertionError);
   });
 
   it('should throw for undefined', () => {
-    expect(() => ensureNonNullable(undefined)).toThrow(AssertError);
+    expect(() => ensureNonNullable(undefined)).toThrow(AssertionError);
   });
 
   it('should throw with custom message', () => {
@@ -116,7 +116,7 @@ describe(ensureNonNullable.name, () => {
 
 describe(assertUnreachable.name, () => {
   it('should always throw', () => {
-    expect(() => assertUnreachable()).toThrow(AssertError);
+    expect(() => assertUnreachable()).toThrow(AssertionError);
   });
 
   it('should throw with custom message', () => {
@@ -127,7 +127,9 @@ describe(assertUnreachable.name, () => {
 
 describe(assertExhaustive.name, () => {
   it('should always throw', () => {
-    expect(() => assertExhaustive('unexpected' as never)).toThrow(AssertError);
+    expect(() => assertExhaustive('unexpected' as never)).toThrow(
+      AssertionError,
+    );
   });
 
   it('should throw with custom message', () => {
@@ -159,7 +161,7 @@ describe('real-world usage examples', () => {
     expect(handleStatus('success')).toBe('Success!');
     expect(handleStatus('error')).toBe('Error occurred');
     expect(() => handleStatus('unexpected' as unknown as Status)).toThrow(
-      AssertError,
+      AssertionError,
     );
   });
 
@@ -185,7 +187,7 @@ describe('real-world usage examples', () => {
       permissions: ['read', 'write'],
     } as IAdminUser;
 
-    expect(() => ensure(regularUser, isAdmin)).toThrow(AssertError);
+    expect(() => ensure(regularUser, isAdmin)).toThrow(AssertionError);
 
     const admin = ensure(adminUser, isAdmin);
     expect(admin.permissions).toEqual(['read', 'write']);

--- a/packages/assert/docs/README.md
+++ b/packages/assert/docs/README.md
@@ -97,10 +97,27 @@ assertNonNullable(user, 'User cannot be null');
 // `user` is narrowed to NonNullable<User>
 ```
 
+### Error Handling (`AssertionError`)
+
+All assertion functions throw `AssertionError` (which extends `Error`) when an assertion fails.
+
+```typescript
+import { assert, AssertionError } from '@rightcapital/assert';
+
+try {
+  assert(user.age >= 18, 'User must be at least 18 years old');
+} catch (error) {
+  if (error instanceof AssertionError) {
+    console.error('Assertion failed:', error.message);
+  }
+}
+```
+
 ## API Summary
 
 | API                              | Return / Type Behavior            | Typical Use Case                                      |
 | :------------------------------- | :-------------------------------- | :---------------------------------------------------- |
+| `AssertionError`                 | `class extends Error`             | Error thrown on assertion failure                     |
 | `assertExhaustive(value, msg?)`  | `never`                           | Enforce exhaustiveness check in `switch` or `if-else` |
 | `assertUnreachable(msg?)`        | `never`                           | Mark logically unreachable code branches              |
 | `ensure(value, predicate, msg?)` | `S extends T`                     | Validate and return value with narrowed type          |

--- a/packages/assert/docs/classes/AssertionError.md
+++ b/packages/assert/docs/classes/AssertionError.md
@@ -1,6 +1,6 @@
-[@rightcapital/assert](../README.md) / [Exports](../modules.md) / AssertError
+[@rightcapital/assert](../README.md) / [Exports](../modules.md) / AssertionError
 
-# Class: AssertError
+# Class: AssertionError
 
 Error thrown when an assertion fails.
 
@@ -8,25 +8,25 @@ Error thrown when an assertion fails.
 
 - `Error`
 
-  ↳ **`AssertError`**
+  ↳ **`AssertionError`**
 
 ## Table of contents
 
 ### Constructors
 
-- [constructor](AssertError.md#constructor)
+- [constructor](AssertionError.md#constructor)
 
 ### Properties
 
-- [message](AssertError.md#message)
-- [name](AssertError.md#name)
-- [stack](AssertError.md#stack)
+- [message](AssertionError.md#message)
+- [name](AssertionError.md#name)
+- [stack](AssertionError.md#stack)
 
 ## Constructors
 
 ### constructor
 
-• **new AssertError**(`message?`): [`AssertError`](AssertError.md)
+• **new AssertionError**(`message?`): [`AssertionError`](AssertionError.md)
 
 #### Parameters
 
@@ -36,7 +36,7 @@ Error thrown when an assertion fails.
 
 #### Returns
 
-[`AssertError`](AssertError.md)
+[`AssertionError`](AssertionError.md)
 
 #### Inherited from
 
@@ -64,7 +64,7 @@ ___
 
 ### name
 
-• **name**: `string` = `'AssertError'`
+• `Readonly` **name**: ``"AssertionError"``
 
 #### Overrides
 
@@ -72,7 +72,7 @@ Error.name
 
 #### Defined in
 
-[packages/assert/src/index.ts:27](https://github.com/RightCapitalHQ/frontend-libraries/blob/318339c/packages/assert/src/index.ts#L27)
+[packages/assert/src/index.ts:25](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L25)
 
 ___
 

--- a/packages/assert/docs/modules.md
+++ b/packages/assert/docs/modules.md
@@ -6,7 +6,7 @@
 
 ### Classes
 
-- [AssertError](classes/AssertError.md)
+- [AssertionError](classes/AssertionError.md)
 
 ### Functions
 
@@ -53,7 +53,7 @@ assert(isValid, 'Data validation failed');
 
 #### Defined in
 
-[packages/assert/src/index.ts:58](https://github.com/RightCapitalHQ/frontend-libraries/blob/318339c/packages/assert/src/index.ts#L58)
+[packages/assert/src/index.ts:56](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L56)
 
 ___
 
@@ -108,7 +108,7 @@ function reducer(action: Action) {
 
 #### Defined in
 
-[packages/assert/src/index.ts:213](https://github.com/RightCapitalHQ/frontend-libraries/blob/318339c/packages/assert/src/index.ts#L213)
+[packages/assert/src/index.ts:211](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L211)
 
 ___
 
@@ -152,7 +152,7 @@ function processUser(user: User | null | undefined) {
 
 #### Defined in
 
-[packages/assert/src/index.ts:81](https://github.com/RightCapitalHQ/frontend-libraries/blob/318339c/packages/assert/src/index.ts#L81)
+[packages/assert/src/index.ts:79](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L79)
 
 ___
 
@@ -196,7 +196,7 @@ function processStatus(status: 'active' | 'inactive' | 'activating') {
 
 #### Defined in
 
-[packages/assert/src/index.ts:176](https://github.com/RightCapitalHQ/frontend-libraries/blob/318339c/packages/assert/src/index.ts#L176)
+[packages/assert/src/index.ts:174](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L174)
 
 ___
 
@@ -250,7 +250,7 @@ const admin = ensure(
 
 #### Defined in
 
-[packages/assert/src/index.ts:115](https://github.com/RightCapitalHQ/frontend-libraries/blob/318339c/packages/assert/src/index.ts#L115)
+[packages/assert/src/index.ts:113](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L113)
 
 ___
 
@@ -298,4 +298,4 @@ const userName = ensureNonNullable(user, 'User not found').name;
 
 #### Defined in
 
-[packages/assert/src/index.ts:144](https://github.com/RightCapitalHQ/frontend-libraries/blob/318339c/packages/assert/src/index.ts#L144)
+[packages/assert/src/index.ts:142](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L142)

--- a/packages/assert/skills/assert/SKILL.md
+++ b/packages/assert/skills/assert/SKILL.md
@@ -12,14 +12,14 @@ metadata:
 
 # assert
 
-Type-safe assertion utilities for defensive TypeScript programming. All functions throw `AssertError` (which extends `Error`) on failure. Default error message format is `${functionName}: Unexpected ${String(value)}`.
+Type-safe assertion utilities for defensive TypeScript programming. All functions throw `AssertionError` (which extends `Error`) on failure. Default error message format is `${functionName}: Unexpected ${String(value)}`.
 
 ## Import
 
 ```typescript
 import {
   assert,
-  AssertError,
+  AssertionError,
   assertExhaustive,
   assertNonNullable,
   assertUnreachable,
@@ -32,7 +32,7 @@ import {
 
 | Class / Function                 | Signature / Return                | Use Case                                                            |
 | -------------------------------- | --------------------------------- | ------------------------------------------------------------------- |
-| `AssertError`                    | `class extends Error`             | Error type thrown when any assertion in this package fails.         |
+| `AssertionError`                 | `class extends Error`             | Error type thrown when any assertion in this package fails.         |
 | `assert(value, msg?)`            | `asserts value`                   | Precondition or boolean check (verifies `value === true`).          |
 | `assertNonNullable(value, msg?)` | `asserts value is NonNullable<T>` | Guard statement against `null` or `undefined`.                      |
 | `ensure(value, predicate, msg?)` | `S extends T`                     | Inline validation using type guard function `(val: T) => val is S`. |
@@ -40,17 +40,17 @@ import {
 | `assertExhaustive(value, msg?)`  | `value: never` -> `never`         | Exhaustiveness check in `switch` `default` case or `if-else` chain. |
 | `assertUnreachable(msg?)`        | `never`                           | Mark logically impossible code paths.                               |
 
-## Error Handling with `AssertError`
+## Error Handling with `AssertionError`
 
-All assertion functions throw `AssertError` when a condition is not met. Use `instanceof AssertError` to catch assertion failures specifically:
+All assertion functions throw `AssertionError` when a condition is not met. Use `instanceof AssertionError` to catch assertion failures specifically:
 
 ```typescript
-import { assert, AssertError } from '@rightcapital/assert';
+import { assert, AssertionError } from '@rightcapital/assert';
 
 try {
   assert(age >= 18, 'User must be an adult');
 } catch (error) {
-  if (error instanceof AssertError) {
+  if (error instanceof AssertionError) {
     console.error('Assertion failed:', error.message);
   } else {
     throw error;

--- a/packages/assert/src/index.ts
+++ b/packages/assert/src/index.ts
@@ -1,6 +1,6 @@
 /**
  * Assertion functions provide type-safe assertions and validation.
- * When assertions fail, they throw `AssertError`.
+ * When assertions fail, they throw `AssertionError`.
  *
  * @author lixiaoyan <lxy.lixiaoyan@gmail.com>
  * @example
@@ -21,19 +21,19 @@
 /**
  * Error thrown when an assertion fails.
  */
-export class AssertError extends Error {
-  public override readonly name = 'AssertError';
+export class AssertionError extends Error {
+  public override readonly name = 'AssertionError';
 }
 
 /**
- * Throws an AssertError for failed assertions.
+ * Throws an AssertionError for failed assertions.
  */
 function throwError(
   name: string,
   value: unknown,
   message: string | undefined,
 ): never {
-  throw new AssertError(message ?? `${name}: Unexpected ${String(value)}`);
+  throw new AssertionError(message ?? `${name}: Unexpected ${String(value)}`);
 }
 
 /**
@@ -41,7 +41,7 @@ function throwError(
  *
  * @param value - The value to assert as truthy
  * @param message - Optional custom error message
- * @throws {AssertError} Throws an error if `value` is not `true`.
+ * @throws {AssertionError} Throws an error if `value` is not `true`.
  *
  * @example
  * ```typescript
@@ -65,7 +65,7 @@ export function assert(value: unknown, message?: string): asserts value {
  *
  * @param value - The value to check for null/undefined
  * @param message - Optional custom error message
- * @throws {AssertError} Throws an error if `value` is `null` or `undefined`.
+ * @throws {AssertionError} Throws an error if `value` is `null` or `undefined`.
  *
  * @example
  * ```typescript
@@ -92,7 +92,7 @@ export function assertNonNullable<T>(
  * @param predicate - Type guard function that validates the value
  * @param message - Optional custom error message
  * @returns The value with narrowed type
- * @throws {AssertError} Throws an error if `predicate` returns `false`.
+ * @throws {AssertionError} Throws an error if `predicate` returns `false`.
  *
  * @example
  * ```typescript
@@ -125,7 +125,7 @@ export function ensure<T, S extends T>(
  * @param value - The value to check for null/undefined
  * @param message - Optional custom error message
  * @returns The non-nullable value
- * @throws {AssertError} Throws an error if `value` is `null` or `undefined`.
+ * @throws {AssertionError} Throws an error if `value` is `null` or `undefined`.
  *
  * @example
  * ```typescript
@@ -155,7 +155,7 @@ export function ensureNonNullable<T>(
  *
  * @param message - Optional custom error message
  * @returns Never returns (always throws)
- * @throws {AssertError} Always thrown.
+ * @throws {AssertionError} Always thrown.
  *
  * @example
  * ```typescript
@@ -182,7 +182,7 @@ export function assertUnreachable(message?: string): never {
  * @param value - The value that should be `never` if all cases are handled
  * @param message - Optional custom error message
  * @returns Never returns (always throws)
- * @throws {AssertError} Always thrown.
+ * @throws {AssertionError} Always thrown.
  *
  * @example
  * ```typescript


### PR DESCRIPTION
## Pull Request type

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [x] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`@rightcapital/assert` exports `AssertError` for assertion failures.

Issue Number: N/A

## What is the new behavior?

- Renames the exported assertion error class to `AssertionError`.
- Updates assertion failure paths, tests, README, skill documentation, and TypeDoc output.
- Adds an independent major-release plan with migration guidance.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

`AssertError` is no longer exported. Update imports and `instanceof AssertError` checks to use `AssertionError`.