### PR TITLE
feat(assert)!: change assert() value parameter type from unknown to b…

### DIFF
--- a/.nx/version-plans/assert-value-boolean.md
+++ b/.nx/version-plans/assert-value-boolean.md
@@ -1,0 +1,7 @@
+---
+assert: major
+---
+
+Change `assert` to accept only boolean conditions.
+
+This is a breaking TypeScript API change. Pass an explicit boolean expression to `assert`, or use `assertNonNullable` for null and undefined checks.

--- a/packages/assert/README.md
+++ b/packages/assert/README.md
@@ -113,15 +113,15 @@ try {
 
 ## API Summary
 
-| API                              | Return / Type Behavior            | Typical Use Case                                      |
-| :------------------------------- | :-------------------------------- | :---------------------------------------------------- |
-| `AssertionError`                 | `class extends Error`             | Error thrown on assertion failure                     |
-| `assertExhaustive(value, msg?)`  | `never`                           | Enforce exhaustiveness check in `switch` or `if-else` |
-| `assertUnreachable(msg?)`        | `never`                           | Mark logically unreachable code branches              |
-| `ensure(value, predicate, msg?)` | `S extends T`                     | Validate and return value with narrowed type          |
-| `ensureNonNullable(value, msg?)` | `NonNullable<T>`                  | Validate non-null/undefined and return value          |
-| `assert(value, msg?)`            | `asserts value`                   | Standard boolean condition assertion                  |
-| `assertNonNullable(value, msg?)` | `asserts value is NonNullable<T>` | Standard non-null/undefined assertion                 |
+| API / Signature                                                                              | Description / Typical Use Case                        |
+| :------------------------------------------------------------------------------------------- | :---------------------------------------------------- |
+| `AssertionError extends Error`                                                               | Error thrown on assertion failure                     |
+| `assertExhaustive(value: never, message?: string): never`                                    | Enforce exhaustiveness check in `switch` or `if-else` |
+| `assertUnreachable(message?: string): never`                                                 | Mark logically unreachable code branches              |
+| `ensure<T, S extends T>(value: T, predicate: (value: T) => value is S, message?: string): S` | Validate and return value with narrowed type          |
+| `ensureNonNullable<T>(value: T, message?: string): NonNullable<T>`                           | Validate non-null/undefined and return value          |
+| `assert(value: boolean, message?: string): asserts value`                                    | Standard boolean condition assertion                  |
+| `assertNonNullable<T>(value: T, message?: string): asserts value is NonNullable<T>`          | Standard non-null/undefined assertion                 |
 
 ## Agent Skills
 

--- a/packages/assert/__tests__/assert.test.ts
+++ b/packages/assert/__tests__/assert.test.ts
@@ -27,14 +27,16 @@ describe(assert.name, () => {
   });
 
   it('should throw when value is falsy', () => {
-    expect(() => assert(null)).toThrow(AssertionError);
-    expect(() => assert(undefined)).toThrow(AssertionError);
     expect(() => assert(false)).toThrow(AssertionError);
-    expect(() => assert(NaN)).toThrow(AssertionError);
-    expect(() => assert(0)).toThrow(AssertionError);
-    expect(() => assert(-0)).toThrow(AssertionError);
-    expect(() => assert(0n)).toThrow(AssertionError);
-    expect(() => assert('')).toThrow(AssertionError);
+    expect(() => assert(null as unknown as boolean)).toThrow(AssertionError);
+    expect(() => assert(undefined as unknown as boolean)).toThrow(
+      AssertionError,
+    );
+    expect(() => assert(NaN as unknown as boolean)).toThrow(AssertionError);
+    expect(() => assert(0 as unknown as boolean)).toThrow(AssertionError);
+    expect(() => assert(-0 as unknown as boolean)).toThrow(AssertionError);
+    expect(() => assert(0n as unknown as boolean)).toThrow(AssertionError);
+    expect(() => assert('' as unknown as boolean)).toThrow(AssertionError);
   });
 
   it('should throw with custom message', () => {

--- a/packages/assert/docs/README.md
+++ b/packages/assert/docs/README.md
@@ -115,15 +115,15 @@ try {
 
 ## API Summary
 
-| API                              | Return / Type Behavior            | Typical Use Case                                      |
-| :------------------------------- | :-------------------------------- | :---------------------------------------------------- |
-| `AssertionError`                 | `class extends Error`             | Error thrown on assertion failure                     |
-| `assertExhaustive(value, msg?)`  | `never`                           | Enforce exhaustiveness check in `switch` or `if-else` |
-| `assertUnreachable(msg?)`        | `never`                           | Mark logically unreachable code branches              |
-| `ensure(value, predicate, msg?)` | `S extends T`                     | Validate and return value with narrowed type          |
-| `ensureNonNullable(value, msg?)` | `NonNullable<T>`                  | Validate non-null/undefined and return value          |
-| `assert(value, msg?)`            | `asserts value`                   | Standard boolean condition assertion                  |
-| `assertNonNullable(value, msg?)` | `asserts value is NonNullable<T>` | Standard non-null/undefined assertion                 |
+| API / Signature                                                                            | Description / Typical Use Case                            |
+| :----------------------------------------------------------------------------------------- | :-------------------------------------------------------- |
+| `AssertionError extends Error`                                                             | Error thrown on assertion failure                         |
+| `assertExhaustive(value: never, message?: string): never`                                  | Enforce exhaustiveness check in `switch` or `if-else`     |
+| `assertUnreachable(message?: string): never`                                               | Mark logically unreachable code branches                  |
+| `ensure<T, S extends T>(value: T, predicate: (value: T) => value is S, message?: string): S` | Validate and return value with narrowed type              |
+| `ensureNonNullable<T>(value: T, message?: string): NonNullable<T>`                        | Validate non-null/undefined and return value              |
+| `assert(value: boolean, message?: string): asserts value`                                 | Standard boolean condition assertion                      |
+| `assertNonNullable<T>(value: T, message?: string): asserts value is NonNullable<T>`       | Standard non-null/undefined assertion                     |
 
 ## Agent Skills
 

--- a/packages/assert/docs/classes/AssertionError.md
+++ b/packages/assert/docs/classes/AssertionError.md
@@ -72,7 +72,7 @@ Error.name
 
 #### Defined in
 
-[packages/assert/src/index.ts:25](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L25)
+[packages/assert/src/index.ts:25](https://github.com/RightCapitalHQ/frontend-libraries/blob/cf018e5/packages/assert/src/index.ts#L25)
 
 ___
 

--- a/packages/assert/docs/modules.md
+++ b/packages/assert/docs/modules.md
@@ -29,7 +29,7 @@ Basic assertion: verifies that a value or expression is `true`, otherwise throws
 
 | Name | Type | Description |
 | :------ | :------ | :------ |
-| `value` | `unknown` | The value to assert as truthy |
+| `value` | `boolean` | The boolean condition to assert as `true` |
 | `message?` | `string` | Optional custom error message |
 
 #### Returns
@@ -53,7 +53,7 @@ assert(isValid, 'Data validation failed');
 
 #### Defined in
 
-[packages/assert/src/index.ts:56](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L56)
+[packages/assert/src/index.ts:56](https://github.com/RightCapitalHQ/frontend-libraries/blob/cf018e5/packages/assert/src/index.ts#L56)
 
 ___
 
@@ -108,7 +108,7 @@ function reducer(action: Action) {
 
 #### Defined in
 
-[packages/assert/src/index.ts:211](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L211)
+[packages/assert/src/index.ts:211](https://github.com/RightCapitalHQ/frontend-libraries/blob/cf018e5/packages/assert/src/index.ts#L211)
 
 ___
 
@@ -152,7 +152,7 @@ function processUser(user: User | null | undefined) {
 
 #### Defined in
 
-[packages/assert/src/index.ts:79](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L79)
+[packages/assert/src/index.ts:79](https://github.com/RightCapitalHQ/frontend-libraries/blob/cf018e5/packages/assert/src/index.ts#L79)
 
 ___
 
@@ -196,7 +196,7 @@ function processStatus(status: 'active' | 'inactive' | 'activating') {
 
 #### Defined in
 
-[packages/assert/src/index.ts:174](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L174)
+[packages/assert/src/index.ts:174](https://github.com/RightCapitalHQ/frontend-libraries/blob/cf018e5/packages/assert/src/index.ts#L174)
 
 ___
 
@@ -250,7 +250,7 @@ const admin = ensure(
 
 #### Defined in
 
-[packages/assert/src/index.ts:113](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L113)
+[packages/assert/src/index.ts:113](https://github.com/RightCapitalHQ/frontend-libraries/blob/cf018e5/packages/assert/src/index.ts#L113)
 
 ___
 
@@ -298,4 +298,4 @@ const userName = ensureNonNullable(user, 'User not found').name;
 
 #### Defined in
 
-[packages/assert/src/index.ts:142](https://github.com/RightCapitalHQ/frontend-libraries/blob/9a2e9d3/packages/assert/src/index.ts#L142)
+[packages/assert/src/index.ts:142](https://github.com/RightCapitalHQ/frontend-libraries/blob/cf018e5/packages/assert/src/index.ts#L142)

--- a/packages/assert/skills/assert/SKILL.md
+++ b/packages/assert/skills/assert/SKILL.md
@@ -30,15 +30,15 @@ import {
 
 ## Quick Reference
 
-| Class / Function                 | Signature / Return                | Use Case                                                            |
-| -------------------------------- | --------------------------------- | ------------------------------------------------------------------- |
-| `AssertionError`                 | `class extends Error`             | Error type thrown when any assertion in this package fails.         |
-| `assert(value, msg?)`            | `asserts value`                   | Precondition or boolean check (verifies `value === true`).          |
-| `assertNonNullable(value, msg?)` | `asserts value is NonNullable<T>` | Guard statement against `null` or `undefined`.                      |
-| `ensure(value, predicate, msg?)` | `S extends T`                     | Inline validation using type guard function `(val: T) => val is S`. |
-| `ensureNonNullable(value, msg?)` | `NonNullable<T>`                  | Inline assignment or method chain for non-null value.               |
-| `assertExhaustive(value, msg?)`  | `value: never` -> `never`         | Exhaustiveness check in `switch` `default` case or `if-else` chain. |
-| `assertUnreachable(msg?)`        | `never`                           | Mark logically impossible code paths.                               |
+| API / Signature                                                                              | Description / Typical Use Case                                      |
+| -------------------------------------------------------------------------------------------- | ------------------------------------------------------------------- |
+| `AssertionError extends Error`                                                               | Error type thrown when any assertion in this package fails.         |
+| `assert(value: boolean, message?: string): asserts value`                                    | Precondition or boolean check (verifies `value === true`).          |
+| `assertNonNullable<T>(value: T, message?: string): asserts value is NonNullable<T>`          | Guard statement against `null` or `undefined`.                      |
+| `ensure<T, S extends T>(value: T, predicate: (value: T) => value is S, message?: string): S` | Inline validation using type guard function `(val: T) => val is S`. |
+| `ensureNonNullable<T>(value: T, message?: string): NonNullable<T>`                           | Inline assignment or method chain for non-null value.               |
+| `assertExhaustive(value: never, message?: string): never`                                    | Exhaustiveness check in `switch` `default` case or `if-else` chain. |
+| `assertUnreachable(message?: string): never`                                                 | Mark logically impossible code paths.                               |
 
 ## Error Handling with `AssertionError`
 

--- a/packages/assert/src/index.ts
+++ b/packages/assert/src/index.ts
@@ -39,7 +39,7 @@ function throwError(
 /**
  * Basic assertion: verifies that a value or expression is `true`, otherwise throws an exception.
  *
- * @param value - The value to assert as truthy
+ * @param value - The boolean condition to assert as `true`
  * @param message - Optional custom error message
  * @throws {AssertionError} Throws an error if `value` is not `true`.
  *
@@ -53,7 +53,7 @@ function throwError(
  * assert(isValid, 'Data validation failed');
  * ```
  */
-export function assert(value: unknown, message?: string): asserts value {
+export function assert(value: boolean, message?: string): asserts value {
   if (value !== true) {
     throwError('assert', value, message);
   }


### PR DESCRIPTION
## Pull Request type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, renaming)
- [ ] Refactoring (no functional changes, no API changes)
- [ ] Build-related changes
- [ ] Documentation content changes
- [ ] Other (please describe):

## What is the current behavior?

`assert()` accepts `unknown` at compile time, even though it only succeeds at runtime when its value is exactly `true`.

Issue Number: N/A

## What is the new behavior?

- Change `assert(value: unknown, message?)` to `assert(value: boolean, message?)`.
- Preserve the existing runtime behavior: values other than `true` still throw `AssertionError`.
- Update tests, API documentation, README/skill API tables, and add a major version plan.

## Does this introduce a breaking change?

- [x] Yes
- [ ] No

Existing callers must pass a boolean condition to `assert()`. For non-boolean values, use an explicit boolean expression that represents the intended assertion.

## Other information

Validated with:

- `pnpm test --project assert`
- `pnpm exec nx run assert:typecheck`
- `pnpm --dir packages/assert run docs`
- `pnpm run check`